### PR TITLE
Prevent price refresh during logout

### DIFF
--- a/frontend/app/src/composables/balances/index.ts
+++ b/frontend/app/src/composables/balances/index.ts
@@ -4,6 +4,7 @@ import { TaskType } from '@/types/task-type';
 import type { AssetPrices } from '@/types/prices';
 import type { MaybeRef } from '@vueuse/core';
 import type { AllBalancePayload } from '@/types/blockchain/accounts';
+import { useSessionAuthStore } from '@/store/session/auth';
 
 export const useBalances = createSharedComposable(() => {
   const { updatePrices: updateManualPrices, fetchManualBalances } = useManualBalancesStore();
@@ -20,6 +21,7 @@ export const useBalances = createSharedComposable(() => {
   const { t } = useI18n();
   const { currencySymbol, currency } = storeToRefs(useGeneralSettingsStore());
   const { fetchNetValue } = useStatisticsStore();
+  const { logged } = storeToRefs(useSessionAuthStore());
 
   const adjustPrices = (prices: MaybeRef<AssetPrices>): void => {
     const pricesConvertedToUsd = { ...get(prices) };
@@ -121,7 +123,8 @@ export const useBalances = createSharedComposable(() => {
 
   // TODO: This is temporary fix for double conversion issue. Future solutions should try to eliminate this part.
   watch(currency, async () => {
-    await refreshPrices(true);
+    if (get(logged))
+      await refreshPrices(true);
   });
 
   return {


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/rotki/blob/develop/docs/usage_guide.rst) to reflect the changes.

Prevents `refreshPrices` from being called unnecessarily during user logout. The `watch` function for currency changes now only triggers `refreshPrices` if a user is currently logged in, avoiding redundant calls when the application state is being reset.

---
<a href="https://cursor.com/background-agent?bcId=bc-622db2bd-7101-4fff-b0ef-d9317a3cc48b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-622db2bd-7101-4fff-b0ef-d9317a3cc48b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

